### PR TITLE
Update build for plugin bundle and maven3.x use

### DIFF
--- a/buildsupport/other/pom.xml
+++ b/buildsupport/other/pom.xml
@@ -32,7 +32,7 @@
       <dependency>
         <groupId>org.sonatype.nexus</groupId>
         <artifactId>nexus-plugin-bundle-model</artifactId>
-        <version>${nexus-plugin-bundle.version}</version>
+        <version>1.2</version> <!-- Model must be in sync: io.takari.nexus:nexus-plugin-bundle-maven-plugin -->
       </dependency>
 
       <dependency>

--- a/plugins/basic/nexus-content-plugin/pom.xml
+++ b/plugins/basic/nexus-content-plugin/pom.xml
@@ -49,7 +49,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
       </plugin>
     </plugins>

--- a/plugins/basic/nexus-crypto-plugin/pom.xml
+++ b/plugins/basic/nexus-crypto-plugin/pom.xml
@@ -69,7 +69,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
         <configuration>
           <sharedDependencies>
@@ -92,7 +92,7 @@
                 <!--
                 BC provider will be installed as a separate bundle to pass signature verification
                 -->
-                <manifest file="${project.build.directory}/nexus-plugin-bundle/osgi.metadata" mode="update">
+                <manifest file="${project.build.directory}/META-INF/MANIFEST.MF" mode="update">
                   <attribute name="Require-Bundle" value="bcprov"/>
                 </manifest>
               </target>

--- a/plugins/basic/nexus-groovy-plugin/pom.xml
+++ b/plugins/basic/nexus-groovy-plugin/pom.xml
@@ -54,7 +54,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
         <configuration>
           <sharedDependencies>

--- a/plugins/basic/nexus-h2-plugin/pom.xml
+++ b/plugins/basic/nexus-h2-plugin/pom.xml
@@ -54,7 +54,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
         <configuration>
           <sharedDependencies>

--- a/plugins/basic/nexus-logging-plugin/pom.xml
+++ b/plugins/basic/nexus-logging-plugin/pom.xml
@@ -59,7 +59,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
       </plugin>
       <plugin>

--- a/plugins/basic/nexus-lvo-plugin/pom.xml
+++ b/plugins/basic/nexus-lvo-plugin/pom.xml
@@ -62,7 +62,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
       </plugin>
 

--- a/plugins/basic/nexus-plugin-console-plugin/pom.xml
+++ b/plugins/basic/nexus-plugin-console-plugin/pom.xml
@@ -63,7 +63,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
       </plugin>
 

--- a/plugins/basic/nexus-rrb-plugin/pom.xml
+++ b/plugins/basic/nexus-rrb-plugin/pom.xml
@@ -64,7 +64,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
       </plugin>
 

--- a/plugins/basic/nexus-siesta-plugin/pom.xml
+++ b/plugins/basic/nexus-siesta-plugin/pom.xml
@@ -101,7 +101,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
         <configuration>
           <sharedDependencies>

--- a/plugins/basic/nexus-site-repository-plugin/pom.xml
+++ b/plugins/basic/nexus-site-repository-plugin/pom.xml
@@ -56,7 +56,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
       </plugin>
 

--- a/plugins/basic/nexus-timeline-plugin/pom.xml
+++ b/plugins/basic/nexus-timeline-plugin/pom.xml
@@ -84,7 +84,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
         <configuration>
           <sharedDependencies>

--- a/plugins/basic/nexus-ui-extjs3-plugin/pom.xml
+++ b/plugins/basic/nexus-ui-extjs3-plugin/pom.xml
@@ -49,7 +49,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
       </plugin>
 

--- a/plugins/basic/nexus-unpack-plugin/pom.xml
+++ b/plugins/basic/nexus-unpack-plugin/pom.xml
@@ -56,7 +56,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
       </plugin>
     </plugins>

--- a/plugins/basic/nexus-webresources-plugin/pom.xml
+++ b/plugins/basic/nexus-webresources-plugin/pom.xml
@@ -49,7 +49,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
       </plugin>
     </plugins>

--- a/plugins/capabilities/nexus-capabilities-plugin/pom.xml
+++ b/plugins/capabilities/nexus-capabilities-plugin/pom.xml
@@ -108,7 +108,7 @@
       </plugin>
 
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
         <configuration>
           <sharedDependencies>

--- a/plugins/capabilities/nexus-capabilities-testsuite-helper/pom.xml
+++ b/plugins/capabilities/nexus-capabilities-testsuite-helper/pom.xml
@@ -46,7 +46,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
       </plugin>
     </plugins>

--- a/plugins/indexer/nexus-indexer-lucene-plugin/pom.xml
+++ b/plugins/indexer/nexus-indexer-lucene-plugin/pom.xml
@@ -100,7 +100,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
         <configuration>
           <sharedDependencies>

--- a/plugins/internal/nexus-atlas-plugin/pom.xml
+++ b/plugins/internal/nexus-atlas-plugin/pom.xml
@@ -85,7 +85,7 @@
       </plugin>
 
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
       </plugin>
 

--- a/plugins/internal/nexus-groovyremote-plugin/pom.xml
+++ b/plugins/internal/nexus-groovyremote-plugin/pom.xml
@@ -73,7 +73,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
       </plugin>
 

--- a/plugins/internal/nexus-kazuki-plugin/pom.xml
+++ b/plugins/internal/nexus-kazuki-plugin/pom.xml
@@ -102,7 +102,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
         <configuration>
           <sharedDependencies>

--- a/plugins/internal/nexus-plexusplugin-plugin/pom.xml
+++ b/plugins/internal/nexus-plexusplugin-plugin/pom.xml
@@ -75,7 +75,7 @@
       </plugin>
 
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
       </plugin>
 

--- a/plugins/internal/nexus-wonderland-plugin/pom.xml
+++ b/plugins/internal/nexus-wonderland-plugin/pom.xml
@@ -90,7 +90,7 @@
       </plugin>
 
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
         <configuration>
           <sharedDependencies>

--- a/plugins/maven/nexus-archetype-plugin/pom.xml
+++ b/plugins/maven/nexus-archetype-plugin/pom.xml
@@ -69,7 +69,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
       </plugin>
     </plugins>

--- a/plugins/maven/nexus-maven-bridge-plugin/pom.xml
+++ b/plugins/maven/nexus-maven-bridge-plugin/pom.xml
@@ -71,7 +71,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
         <configuration>
           <sharedDependencies>

--- a/plugins/npm/nexus-npm-repository-plugin/pom.xml
+++ b/plugins/npm/nexus-npm-repository-plugin/pom.xml
@@ -79,18 +79,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
-        <extensions>true</extensions>
-        <executions>
-          <execution>
-            <id>create-plugin-bundle</id>
-            <goals>
-              <goal>create-bundle</goal>
-            </goals>
-            <phase>package</phase>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>

--- a/plugins/osgi/nexus-obr-plugin/pom.xml
+++ b/plugins/osgi/nexus-obr-plugin/pom.xml
@@ -73,7 +73,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
       </plugin>
 

--- a/plugins/p2/nexus-p2-bridge-plugin/pom.xml
+++ b/plugins/p2/nexus-p2-bridge-plugin/pom.xml
@@ -152,7 +152,7 @@
       </plugin>
 
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
         <configuration>
           <assemblyDescriptor>${project.basedir}/src/main/assemble/bundle.xml</assemblyDescriptor>

--- a/plugins/p2/nexus-p2-repository-plugin/pom.xml
+++ b/plugins/p2/nexus-p2-repository-plugin/pom.xml
@@ -75,7 +75,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
       </plugin>
     </plugins>

--- a/plugins/restlet1x/nexus-restlet1x-plugin/pom.xml
+++ b/plugins/restlet1x/nexus-restlet1x-plugin/pom.xml
@@ -85,7 +85,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
         <configuration>
           <sharedDependencies>

--- a/plugins/restlet1x/nexus-restlet1x-testsupport-plugin/pom.xml
+++ b/plugins/restlet1x/nexus-restlet1x-testsupport-plugin/pom.xml
@@ -54,7 +54,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
       </plugin>
     </plugins>

--- a/plugins/rubygem/nexus-ruby-plugin/pom.xml
+++ b/plugins/rubygem/nexus-ruby-plugin/pom.xml
@@ -55,7 +55,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
       </plugin>
     </plugins>

--- a/plugins/security/nexus-kenai-plugin/pom.xml
+++ b/plugins/security/nexus-kenai-plugin/pom.xml
@@ -61,7 +61,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
       </plugin>
 

--- a/plugins/security/nexus-ldap-realm-plugin/pom.xml
+++ b/plugins/security/nexus-ldap-realm-plugin/pom.xml
@@ -106,7 +106,7 @@
       </plugin>
 
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
         <configuration>
           <sharedDependencies>

--- a/plugins/security/nexus-rutauth-plugin/pom.xml
+++ b/plugins/security/nexus-rutauth-plugin/pom.xml
@@ -57,7 +57,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
       </plugin>
     </plugins>

--- a/plugins/yum/nexus-yum-repository-plugin/pom.xml
+++ b/plugins/yum/nexus-yum-repository-plugin/pom.xml
@@ -99,7 +99,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <!--
     Configuration of 'nexus-plugin' packaging and bundles.
     -->
-    <nexus-plugin-bundle.version>1.2</nexus-plugin-bundle.version>
+    <nexus-plugin-bundle.version>1.5</nexus-plugin-bundle.version>
     <nexus-plugin.type>nexus-plugin</nexus-plugin.type>
 
     <!-- logging configuration used in logback config files to control test logging -->
@@ -521,7 +521,7 @@
         Support for nexus-plugin packaging.
         -->
         <plugin>
-          <groupId>org.sonatype.nexus</groupId>
+          <groupId>io.takari.nexus</groupId>
           <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
           <version>${nexus-plugin-bundle.version}</version>
           <extensions>true</extensions>
@@ -660,13 +660,6 @@
             <configuration>
               <fail>true</fail>
               <rules>
-                <!--
-                Require Maven 3.0.4+, but not Maven 3.1+
-                -->
-                <requireMavenVersion>
-                  <version>[3.0.4,3.1)</version>
-                </requireMavenVersion>
-
                 <!--
                 Require Java 7+
                 -->
@@ -1063,7 +1056,7 @@
                     </pluginExecution>
                     <pluginExecution>
                       <pluginExecutionFilter>
-                        <groupId>org.sonatype.nexus</groupId>
+                        <groupId>io.takari.nexus</groupId>
                         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
                         <versionRange>[1.0,)</versionRange>
                         <goals>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -94,7 +94,7 @@
       Need to know about 'nexus-plugin' packaging for integration-tests.
       -->
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
       </plugin>
     </plugins>

--- a/testsupport/nexus-it-helper-plugin/pom.xml
+++ b/testsupport/nexus-it-helper-plugin/pom.xml
@@ -61,7 +61,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.nexus</groupId>
+        <groupId>io.takari.nexus</groupId>
         <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
       </plugin>
     </plugins>


### PR DESCRIPTION
Use io.takari.nexus plugin for plugin bundles and remove enforcer for maven 3.0.x. This makes build workable with latest Maven 3.x and also debuggable in Nexus IDE.