### PR TITLE
don't use dots in envar names

### DIFF
--- a/components/nexus-bootstrap/src/main/java/org/sonatype/nexus/bootstrap/Launcher.java
+++ b/components/nexus-bootstrap/src/main/java/org/sonatype/nexus/bootstrap/Launcher.java
@@ -44,7 +44,7 @@ import static org.sonatype.nexus.bootstrap.monitor.KeepAliveThread.KEEP_ALIVE_TI
 public class Launcher
 {
   // FIXME: Move this to CommandMonitorThread
-  public static final String COMMAND_MONITOR_PORT = CommandMonitorThread.class.getName() + ".port";
+  public static final String COMMAND_MONITOR_PORT = "COMMAND_MONITOR_PORT";
 
   public static final String SYSTEM_USERID = "*SYSTEM";
 

--- a/components/nexus-bootstrap/src/main/java/org/sonatype/nexus/bootstrap/monitor/KeepAliveThread.java
+++ b/components/nexus-bootstrap/src/main/java/org/sonatype/nexus/bootstrap/monitor/KeepAliveThread.java
@@ -29,11 +29,11 @@ public class KeepAliveThread
 {
   // NOTE: Avoiding any logging our sysout usage by this class, this could lockup logging when its detected remote unreachable
 
-  public static final String KEEP_ALIVE_PORT = KeepAliveThread.class.getName() + ".port";
+  public static final String KEEP_ALIVE_PORT = "KEEP_ALIVE_PORT";
 
-  public static final String KEEP_ALIVE_PING_INTERVAL = KeepAliveThread.class.getName() + ".pingInterval";
+  public static final String KEEP_ALIVE_PING_INTERVAL = "KEEP_ALIVE_PING_INTERVAL";
 
-  public static final String KEEP_ALIVE_TIMEOUT = KeepAliveThread.class.getName() + ".timeout";
+  public static final String KEEP_ALIVE_TIMEOUT = "KEEP_ALIVE_TIMEOUT";
 
   private final CommandMonitorTalker talker;
 

--- a/components/nexus-launcher/src/main/java/org/sonatype/nexus/bundle/launcher/internal/NexusITLauncher.java
+++ b/components/nexus-launcher/src/main/java/org/sonatype/nexus/bundle/launcher/internal/NexusITLauncher.java
@@ -51,7 +51,7 @@ public class NexusITLauncher
    * Name of environment variable/system property to be looked up for the port number of command monitor thread.
    * If not present, command monitor will not be started.
    */
-  public static final String COMMAND_MONITOR_PORT = NexusITLauncher.class.getName() + ".monitor.port";
+  public static final String COMMAND_MONITOR_PORT = "COMMAND_MONITOR_PORT";
 
   /**
    * 5 seconds in milliseconds.


### PR DESCRIPTION
ITs from `nexus-2.x-additions` repo are failing on a local linux with:
```
2016-08-02 09:27:59,501 INFO [main] io.takari.nexus.testsuite.security.DefRoleRealmIT - TEST realmEnabledWithCapability[0] FAILED
java.lang.AssertionError: Nexus was not in running state
    at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:26) ~[hamcrest-core-1.3.jar:1.3]
    at org.sonatype.nexus.testsuite.support.NexusRunningITSupport.beforeTestIsRunning(NexusRunningITSupport.java:109) ~[nexus-testsuite-support-2.13.0-01.jar:2.13.0-01]
```

The problem is that `DefaultNexusBundle` is trying to pass some stuff as enviroments variables with dots in their names.

Which is generally a bad idea and not really supported by standard shells. From `man 1 bash`:
```DEFINITIONS
    ...   
    name   A word consisting only of alphanumeric characters and underscores, and beginning with an alphabetic character or an underscore.  Also referred to as an identifier.
```
Same thing with ksh and others.